### PR TITLE
Mark injected resources with attribute 'data-spark-injected' for furt…

### DIFF
--- a/build/tasks/dist/prepare-index.js
+++ b/build/tasks/dist/prepare-index.js
@@ -4,15 +4,30 @@ var path = require('path');
 var join = path.join;
 
 module.exports = function(config) {
-  gulp.task('dist:index', function() {
-      gulp.src(config.paths.app.index, {'base': 'src'})
-          .pipe(inject(gulp.src(config.paths.lib.styles.prod, {'read': false}), {
-              'ignorePath': 'bower_components',
-              'addRootSlash': false,
-              name: 'lib'
-          }))
-          .pipe(inject(gulp.src(join(config.distDir, '/all.css'), {'read': false}), {'ignorePath': config.distDir, 'addRootSlash': false}))
-          .pipe(inject(gulp.src(join(config.distDir, '/all.js'), {'read': false}), {'ignorePath': config.distDir, 'addRootSlash': false}))
-          .pipe(gulp.dest(config.distDir))
-  });
+    gulp.task('dist:index', function() {
+        gulp.src(config.paths.app.index, {'base': 'src'})
+            .pipe(inject(gulp.src(config.paths.lib.styles.prod, {'read': false}), {
+                'ignorePath': 'bower_components',
+                'addRootSlash': false,
+                name: 'lib',
+                'transform': function(filepath) {
+                    return '<link data-spark-injected rel="stylesheet" href="' + filepath + '">'
+                }
+            }))
+            .pipe(inject(gulp.src(join(config.distDir, '/all.css'), {'read': false}), {
+                'ignorePath': config.distDir,
+                'addRootSlash': false,
+                'transform': function(filepath) {
+                    return '<link data-spark-injected rel="stylesheet" href="' + filepath + '">'
+                }
+            }))
+            .pipe(inject(gulp.src(join(config.distDir, '/all.js'), {'read': false}), {
+                'ignorePath': config.distDir,
+                'addRootSlash': false,
+                'transform': function (filepath) {
+                    return '<script data-spark-injected src="' + filepath + '"></script>';
+                }
+            }))
+            .pipe(gulp.dest(config.distDir))
+    });
 };


### PR DESCRIPTION
…her processing on the server. This is required for the resource caching feature of spark.

Also see this PR: https://github.com/K15t/spark/pull/5
