### PR TITLE
Update "require-dir" package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "karma-phantomjs-launcher": "0.1.4",
     "mkdirp": "0.5.0",
     "node.extend": "1.1.3",
-    "require-dir": "0.3.0",
+    "require-dir": "0.3.2",
     "run-sequence": "1.0.2",
     "stream-series": "0.1.1",
     "stringify-object": "2.0.0"


### PR DESCRIPTION
Update "require-dir" package version due to the problem with new nodejs versions:
Version 0.3.0 doesn't work with new versions of NodeJS